### PR TITLE
Replace bzero() to memset().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ COPYING
 
 #Ctags
 tags
+*.taghl
 
 #Python
 *.pyc

--- a/src/common/log.c
+++ b/src/common/log.c
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 #include <strings.h>
+#include <string.h>
 
 cceph_atomic64_t cceph_g_log_id = { 0 };
 
@@ -24,7 +25,7 @@ void _cceph_log(int level, int64_t log_id, const char* file, int line, const cha
     va_list args;
     va_start(args, fmt);
     char buffer[MAX_LOG_ENTRY_LENGTH];
-    bzero(buffer, MAX_LOG_ENTRY_LENGTH);
+    memset(buffer, 0, sizeof(buffer));
 
     int offset = sprintf(buffer, "[logid %ld]", log_id);
     offset += sprintf(buffer + offset, "[%s:%d]", file, line);

--- a/src/common/option.c
+++ b/src/common/option.c
@@ -1,7 +1,7 @@
 #include "option.h"
 
 #include <stdlib.h>
-#include <strings.h>
+#include <string.h>
 
 #include "common/assert.h"
 #include "common/types.h"
@@ -9,7 +9,7 @@
 cceph_option g_cceph_option;
 
 int cceph_option_initial() {
-    bzero(&g_cceph_option, sizeof(cceph_option));
+    memset(&g_cceph_option, 0, sizeof(g_cceph_option));
     g_cceph_option.client_msg_workthread_count = 2;
     g_cceph_option.client_debug_check_duplicate_req_when_ack = 1;
 

--- a/src/message/messenger.c
+++ b/src/message/messenger.c
@@ -230,7 +230,7 @@ void* start_epoll(void* arg) {
     assert(log_id, messenger->epoll_fd != -1);
 
     struct epoll_event event;
-    bzero(&event, sizeof(event));
+    memset(&event, 0, sizeof(event));
     while (1) {
         int fd_count = epoll_wait(messenger->epoll_fd, &event, 1, -1);
         if (fd_count <= 0) {
@@ -480,7 +480,7 @@ cceph_conn_id_t cceph_messenger_get_conn(
     LOG(LL_DEBUG, log_id, "Conn for %s:%d is not found in current conn_list, try to connect.", host, port);
 
     struct sockaddr_in server_addr_in;
-    bzero(&server_addr_in, sizeof(server_addr_in) );
+    memset(&server_addr_in, 0, sizeof(server_addr_in) );
     server_addr_in.sin_family = AF_INET;
     server_addr_in.sin_port = htons(port);
     inet_pton(AF_INET, host, &server_addr_in.sin_addr);

--- a/src/message/msg_write_obj.c
+++ b/src/message/msg_write_obj.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <strings.h>
+#include <string.h>
 #include <unistd.h>
 #include <arpa/inet.h>
 
@@ -13,7 +14,7 @@
 
 cceph_msg_write_obj_req* cceph_msg_write_obj_req_new() {
     cceph_msg_write_obj_req* req = malloc(sizeof(cceph_msg_write_obj_req));
-    bzero(req, sizeof(cceph_msg_write_obj_req));
+    memset(req, 0, sizeof(cceph_msg_write_obj_req));
     req->header.op = CCEPH_MSG_OP_WRITE;
     return req;
 }
@@ -62,7 +63,7 @@ int cceph_msg_write_obj_req_recv(int fd, cceph_msg_write_obj_req* req, int64_t l
 
 cceph_msg_write_obj_ack* cceph_msg_write_obj_ack_new() {
     cceph_msg_write_obj_ack* msg = malloc(sizeof(cceph_msg_write_obj_ack));
-    bzero(msg, sizeof(cceph_msg_write_obj_ack));
+    memset(msg, 0, sizeof(cceph_msg_write_obj_ack));
     msg->header.op = CCEPH_MSG_OP_WRITE_ACK;
     return msg;
 }

--- a/src/message/server_messenger.c
+++ b/src/message/server_messenger.c
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <strings.h>
+#include <string.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -33,7 +34,7 @@ int cceph_server_messenger_new(
         return CCEPH_ERR_NO_ENOUGH_MEM;
     }
 
-    bzero(server_messenger, sizeof(cceph_server_messenger));
+    memset(server_messenger, 0, sizeof(cceph_server_messenger));
     server_messenger->messenger = messenger;
     server_messenger->port = port;
     server_messenger->log_id = log_id;
@@ -64,11 +65,11 @@ int bind_and_listen(cceph_server_messenger *server_messenger, int64_t log_id) {
 
     //set server addr_param
     struct sockaddr_in my_addr;
-    bzero(&my_addr, sizeof(my_addr));
+    memset(&my_addr, 0, sizeof(my_addr));
     my_addr.sin_family = AF_INET;
     my_addr.sin_port = htons(port);
     my_addr.sin_addr.s_addr = INADDR_ANY;
-    bzero(&(my_addr.sin_zero), 8);
+    memset(&(my_addr.sin_zero), 0, sizeof(my_addr.sin_zero));
 
     //bind sockfd & addr
     int ret = bind(listen_fd, (struct sockaddr*)&my_addr, sizeof(struct sockaddr_in));

--- a/src/os/mem_store.c
+++ b/src/os/mem_store.c
@@ -13,7 +13,7 @@
 
 cceph_os_funcs* cceph_mem_store_get_funcs() {
     cceph_os_funcs *os_funcs = (cceph_os_funcs*)malloc(sizeof(cceph_os_funcs));
-    bzero(os_funcs, sizeof(cceph_os_funcs));
+    memset(os_funcs, 0, sizeof(cceph_os_funcs));
 
     os_funcs->mount             = cceph_mem_store_mount;
     os_funcs->submit_tran       = cceph_mem_store_submit_tran;
@@ -233,7 +233,7 @@ int cceph_mem_store_do_op_obj_write(
         }
 
         //cp old data to new data;
-        bzero(new_data, new_length);
+        memset(new_data, 0, new_length);
         memcpy(new_data, onode->data, onode->length);
 
         char* old_data = onode->data;

--- a/src/os/mem_store_object_node.c
+++ b/src/os/mem_store_object_node.c
@@ -24,7 +24,7 @@ int cceph_mem_store_object_node_new(
         *node = NULL;
         return CCEPH_ERR_NO_ENOUGH_MEM;
     }
-    bzero((*node)->oid, oid_length);
+    memset((*node)->oid, 0, oid_length);
     strcpy((*node)->oid, oid);
 
     (*node)->data   = NULL;

--- a/src/os/types.c
+++ b/src/os/types.c
@@ -63,7 +63,7 @@ int cceph_os_map_node_new(
         *node = NULL;
         return CCEPH_ERR_NO_ENOUGH_MEM;
     }
-    bzero((*node)->key, key_length);
+    memset((*node)->key, 0, key_length);
     strcpy((*node)->key, key);
 
     if (value_length > 0) {

--- a/src/test/test_message_messenger.cc
+++ b/src/test/test_message_messenger.cc
@@ -236,7 +236,7 @@ cceph_msg_write_obj_req* get_cceph_msg_write_obj_req() {
     req->offset        = 0;
     req->length        = 1024;
     req->data          = (char*)malloc(sizeof(char) * 1024);
-    bzero(req->oid, req->oid_size);
+    memset(req->oid, 0, req->oid_size);
     strcpy(req->oid, (char*)"cceph_oid");
     return req;
 }
@@ -294,11 +294,11 @@ void* listen_thread_func(void* arg_ptr){
 
     //set server addr_param
     struct sockaddr_in my_addr;
-    bzero(&my_addr, sizeof(my_addr));
+    memset(&my_addr, 0, sizeof(my_addr));
     my_addr.sin_family = AF_INET;
     my_addr.sin_port = htons(port);
     my_addr.sin_addr.s_addr = INADDR_ANY;
-    bzero(&(my_addr.sin_zero), 8);
+    memset(&(my_addr.sin_zero), 0, sizeof(my_addr.sin_zero));
 
     //bind sockfd & addr
     int ret = bind(listen_fd, (struct sockaddr*)&my_addr, sizeof(struct sockaddr_in));
@@ -435,7 +435,7 @@ TEST(message_messenger, send_and_recv) {
     their_addr.sin_family = AF_INET;
     their_addr.sin_port = htons(port);
     inet_aton( "127.0.0.1", &their_addr.sin_addr);
-    bzero(&(their_addr.sin_zero),8);
+    memset(&(their_addr.sin_zero), 0, sizeof(their_addr.sin_zero));
 
     int ret = connect(fd, (struct sockaddr *)&their_addr, sizeof(struct sockaddr));
     EXPECT_NE(-1, ret);

--- a/src/test/test_os.cc
+++ b/src/test/test_os.cc
@@ -354,7 +354,7 @@ TEST_F(os, object_write_and_read_multithread) {
         EXPECT_EQ(CCEPH_OK, ret);
 
         char* oid = (char*)malloc(sizeof(char) * 256);
-        bzero(oid, 256);
+        memset(oid, 0, 256);
         sprintf(oid, "%d", i);
 
         write_read_thread_arg *arg = (write_read_thread_arg*)malloc(sizeof(write_read_thread_arg));

--- a/src/test/test_os_mem_store_object_node.cc
+++ b/src/test/test_os_mem_store_object_node.cc
@@ -12,7 +12,7 @@ TEST(cceph_mem_store, object_node) {
     cceph_mem_store_object_node* node       = NULL;
 
     for (int i = 0; i < 1000; i++) {
-        bzero(oid, 256);
+        memset(oid, 0, 256);
         sprintf(oid, "%d", i);
 
         node = NULL;
@@ -27,7 +27,7 @@ TEST(cceph_mem_store, object_node) {
         EXPECT_EQ(CCEPH_OK, ret);
     }
     for (int i = 0; i < 1000; i++) {
-        bzero(oid, 256);
+        memset(oid, 0, 256);
         sprintf(oid, "%d", i);
 
         node = NULL;

--- a/src/test/test_os_types.cc
+++ b/src/test/test_os_types.cc
@@ -19,7 +19,7 @@ TEST(os_types, cceph_os_map_node) {
     cceph_os_map_node *node = NULL;
 
     for (int i = 0; i < 1000; i++) {
-        bzero(key, 256);
+        memset(key, 0, 256);
         sprintf(key, "%d", i);
 
         node = NULL;
@@ -34,7 +34,7 @@ TEST(os_types, cceph_os_map_node) {
         EXPECT_EQ(CCEPH_OK, ret);
     }
     for (int i = 0; i < 1000; i++) {
-        bzero(key, 256);
+        memset(key, 0, 0256);
         sprintf(key, "%d", i);
 
         node = NULL;


### PR DESCRIPTION
bzero() was deprecated in IEEE Std 1003.1-2001 (``POSIX.1'') and removed
 in IEEE Std 1003.1-2008 (``POSIX.1'').

Signed-off-by: KetorD <d.ketor@gmail.com>